### PR TITLE
Fix UnicodeEncodeError

### DIFF
--- a/gg_dorking.py
+++ b/gg_dorking.py
@@ -112,5 +112,5 @@ for key in config._dict.keys():
 print(colored(f'Writing output to file "{output}"', "white", attrs=["bold"]))
 out = index_template.render(sections=sections)
 
-out_f = open(output, "w+")
+out_f = open(output, "w+", encoding="utf-8")
 print(out, file=out_f)


### PR DESCRIPTION
Fix for UnicodeEncodeError: 'charmap' codec can't encode characters in position 92572-92573: character maps to <undefined>